### PR TITLE
Added snippets for logrus and testify assert

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ Below is a list of all available snippets and the triggers of each one.
 | `frr`   | for range channel `for v := range channel { myStatements }`|
 | `def`   | case default `default:` |
 | `cl`   | close `close(closable)` |
-| `fms`   | fmt Sprinf `fmt.Sprintf("%+v", args)` |
+| `fms`   | fmt Sprintf `fmt.Sprintf("%+v", args)` |
+| `fme`   | fmt Errorf `fmt.Errorf("%+v", args)` |
 
 
 ### Types
@@ -70,6 +71,9 @@ Below is a list of all available snippets and the triggers of each one.
 | :------- | ------- |
 | `lo`   | log variable `log.Printf("%+v\n", varName)` |
 | `le`   | log error `log.Printf("%+v\n", err)` |
+| `lef`   | log error (when using logrus) `log.Errorf("%+v\n", err)` |
+| `lf`   | log fatal `log.Fatal(err)` |
+| `lff`   | log fatal `log.Fatalf("%+v\n", err)` |
 
 
 ### Error Handling
@@ -90,6 +94,13 @@ Below is a list of all available snippets and the triggers of each one.
 | `lock`   | sync.Mutex Lock and defer Unlock <pre>mu.Lock()<br/>defer mu.Unlock()</pre>|
 | `nb` | non-blocking channel send <pre>select {<br/>case msg &lt;- msgChan:<br/>default:<br/>}</pre>|
 
+### Testify Assert
+| Prefix  | Content |
+| :------- | ------- |
+| `anil`   | assert nil `assert.Nil(t, actual)` |
+| `annil`   | assert not nil `assert.NotNil(t, actual)` |
+| `aeq`   | assert nil `assert.Equal(t, expected, actual)` |
+| `anerr`   | assert nil `assert.NoError(t, err)` |
 
 [code]: https://code.visualstudio.com/
 [coffee]: https://buy.stripe.com/9AQ9DA6qq3Afbrq7ss

--- a/README.md
+++ b/README.md
@@ -99,8 +99,13 @@ Below is a list of all available snippets and the triggers of each one.
 | :------- | ------- |
 | `anil`   | assert nil `assert.Nil(t, actual)` |
 | `annil`   | assert not nil `assert.NotNil(t, actual)` |
-| `aeq`   | assert nil `assert.Equal(t, expected, actual)` |
-| `anerr`   | assert nil `assert.NoError(t, err)` |
+| `aeq`   | assert equal `assert.Equal(t, expected, actual)` |
+| `anerr`   | assert no error `assert.NoError(t, err)` |
+
+### Import
+| Prefix  | Content |
+| :------- | ------- |
+| `logrus`   | import logrus `log "github.com/sirupsen/logrus"` |
 
 [code]: https://code.visualstudio.com/
 [coffee]: https://buy.stripe.com/9AQ9DA6qq3Afbrq7ss

--- a/snippets/snippets.code-snippets
+++ b/snippets/snippets.code-snippets
@@ -208,4 +208,12 @@
       "$0"
     ]
   },
+  "Logrus import": {
+		"description": "logrus import snippet that 'overwrites' standard log lib",
+		"prefix": "logrus",
+		"body": [
+		  "${1:log} \"github.com/sirupsen/logrus\"",
+		  "$0"
+		]
+  },
 }

--- a/snippets/snippets.code-snippets
+++ b/snippets/snippets.code-snippets
@@ -50,15 +50,35 @@
     "prefix": "lo",
     "body": ["log.Printf(\"${1:%+v}\\n\", $0)"]
   },
-
+   
   "log.Printf err": {
     "prefix": "le",
     "body": ["log.Printf(\"${1:%+v}\\n\", err)"]
   },
+          
+  "log.Fatal": {
+      "prefix": "lf",
+      "body": ["log.Fatal(${0:err})"]
+  },
 
-  "fmt Sprintf": {
+  "log.Fatalf": {
+      "prefix": "lff",
+      "body": ["log.Fatalf(\"${1:%+v}\\n\", ${0:err})"]
+  },
+  
+  "log.Errorf": {
+    "prefix": "lef",
+    "body": ["log.Errorf(\"${1:%+v}\\n\", ${0:err})"]
+  },
+
+  "fmt.Sprintf": {
     "prefix": "fms",
     "body": ["fmt.Sprintf(\"${1:%+v}\", $0)"]
+  },
+
+  "fmt.Errorf": {
+    "prefix": "fme",
+    "body": ["fmt.Errorf(\"${1:%+v}\", ${0:err})"]
   },
 
   "if error": {
@@ -156,5 +176,36 @@
   "Non-blocking Channel Send": {
     "prefix": "nb",
     "body": ["select {", "case $1 <- $0:", "default:", "}"]
-  }
+  },
+  
+  "Testify Assert Nil": {
+    "prefix": "anil",
+    "body": [
+      "assert.Nil(t, ${1:actual})", 
+      "$0"
+    ]
+  },
+  "Testify Assert Not Nil": {
+    "prefix": "annil",
+    "body": [
+      "assert.NotNil(t, ${1:actual})", 
+      "$0"
+    ]
+  },
+
+  "Testify Assert Equal": {
+    "prefix": "aeq",
+    "body": [
+      "assert.Equal(t, ${1:expected}, ${2:actual})",
+      "$0"
+    ]
+  },
+
+  "Testify Assert No Error": {
+    "prefix": "anerr",
+    "body": [
+      "assert.NoError(t, ${1:err})",
+      "$0"
+    ]
+  },
 }


### PR DESCRIPTION
I've added some snippets that are used frequently by me and my colleagues while unit testing and error handling and logging. For example:
- fmt.Errorf() snippet, 
- logrus Fatal(), Fatalf(), Errorf(), 
- stretchr testify assert basic snippets.